### PR TITLE
build: fix incorrect lerna publish behavior

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,8 @@
   "npmClient": "pnpm",
   "command": {
     "publish": {
-      "message": "chore(release): publish"
+      "message": "chore(release): publish",
+      "verifyAccess": false
     },
     "bootstrap": {
       "ignore": "*"


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.2--canary.7.05cabba.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @snowstorm/cli@0.1.2--canary.7.05cabba.0
  npm install @snowstorm/core@0.1.2--canary.7.05cabba.0
  npm install @snowstorm/head@0.1.2--canary.7.05cabba.0
  npm install @snowstorm/serverprops@0.1.2--canary.7.05cabba.0
  # or 
  yarn add @snowstorm/cli@0.1.2--canary.7.05cabba.0
  yarn add @snowstorm/core@0.1.2--canary.7.05cabba.0
  yarn add @snowstorm/head@0.1.2--canary.7.05cabba.0
  yarn add @snowstorm/serverprops@0.1.2--canary.7.05cabba.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
