### PR TITLE
fix: fix ssr preload

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,13 +34,14 @@
     "build:client": "esbuild src/client/index.tsx src/client/load-html.tsx src/client/_error.tsx src/client/router/index.tsx --bundle --splitting --chunk-names=../chunks/[name]-[hash] --outdir=client --platform=node --target=node16 --format=esm --metafile=client.meta.json --external:_snowstorm* --external:wouter --external:@snowstorm/* --external:react --external:react-dom --minify",
     "build:index": "esbuild src/index.ts --outdir=. --platform=node --target=node16 --format=esm --minify",
     "build:server": "esbuild src/server.ts src/server/export.ts --bundle --splitting --chunk-names=chunks/[name]-[hash] --outdir=. --platform=node --target=node16 --format=esm --metafile=server.meta.json --external:wouter --external:typescript --external:node-fetch --external:vite --external:@vitejs/* --banner:js='import { createRequire as topLevelCreateRequire } from \"module\";\n const require = topLevelCreateRequire(import.meta.url);'",
-    "clean": "rimraf -rf index.d.ts index.js index.js.map server.d.ts server.js server.meta.json client.meta.json server/ client/",
+    "clean": "rimraf -rf index.d.ts index.js index.js.map server.d.ts server.js server.meta.json client.meta.json server/ client/ chunks/ lib/",
     "types": "run-p --print-label types:**",
     "types:client": "tsc -p tsconfig.client.json",
     "types:server": "tsc -p tsconfig.server.json",
     "watch": "run-p --print-label \"build:** -- --watch\""
   },
   "dependencies": {
+    "@rollup/pluginutils": "^4.1.1",
     "@snowstorm/head": "link:../head",
     "@snowstorm/serverprops": "link:../serverprops",
     "@vitejs/plugin-react-refresh": "^1.3.6",

--- a/packages/core/src/server/config.ts
+++ b/packages/core/src/server/config.ts
@@ -208,7 +208,7 @@ export const loadConfig = async (
 const processSites = async (
 	config: SnowstormConfigInternal,
 ): Promise<SnowstormSiteConfigInternal[]> => {
-	const sites = [config.site];
+	const sites = [];
 
 	if (config.sitesFolder) {
 		const sitesContent = await glob(
@@ -230,6 +230,8 @@ const processSites = async (
 				),
 			);
 		}
+	} else {
+		sites.push(config.site);
 	}
 
 	return (

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -13,7 +13,7 @@ import { rejects } from 'assert';
 import { createServer } from 'http';
 const require = createRequire(import.meta.url);
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const pkg = require('./../package.json');
 process.setMaxListeners(10000);
 
@@ -98,6 +98,7 @@ export const start = async ({
 	});
 
 	log.info(`started in ${Math.round(performance.now() - serverStart)}ms`);
+
 	listening
 		.then(() => {
 			startSites.forEach(({ site }) => {

--- a/packages/core/src/server/ssr.ts
+++ b/packages/core/src/server/ssr.ts
@@ -171,7 +171,7 @@ const collectPreload = async (
 			const isPage =
 				key.includes(`/pages/${page}.`) &&
 				/.(js|mjs|jsx|ts|tsx|md|mdx)$/.test(key);
-			const isDep = children.some(c => key.includes(c));
+			const isDep = children?.some(c => key.includes(c)) || false;
 			return isPage || isDep;
 		})
 		.map(x => x[1])

--- a/packages/core/src/server/ssr.ts
+++ b/packages/core/src/server/ssr.ts
@@ -10,8 +10,6 @@ const startDate = Date.now();
 const version = startDate.toString();
 const ABORT_DELAY = 2000;
 
-let manifest: Record<string, string[]> | undefined;
-
 export const ssr =
 	({
 		devServer,
@@ -35,6 +33,7 @@ export const ssr =
 			}
 		}
 
+		let manifest: Record<string, string[]> | undefined;
 		if (!dev && !manifest) {
 			const loc = join(site.internal.viteFolder, './client/ssr-manifest.json');
 			if (await checkFileExists(loc)) {

--- a/packages/core/src/server/ssr.ts
+++ b/packages/core/src/server/ssr.ts
@@ -10,7 +10,7 @@ const startDate = Date.now();
 const version = startDate.toString();
 const ABORT_DELAY = 2000;
 
-let manifest: Record<string, unknown> | undefined;
+let manifest: Record<string, string[]> | undefined;
 
 export const ssr =
 	({
@@ -66,7 +66,7 @@ export const ssr =
 
 			let internalHead = '';
 			if (!dev && manifest) {
-				internalHead = await collectPreload(page.page, site, manifest);
+				internalHead = await collectPreload(page.page, site, config, manifest);
 			}
 
 			await serverprops.processSPs();
@@ -154,47 +154,38 @@ export const ssr =
 const collectPreload = async (
 	page: string,
 	site: SnowstormSiteConfigInternal,
-	manifest: Record<string, unknown>,
+	config: SnowstormConfigInternal,
+	manifest: Record<string, string[]>,
 ) => {
 	const children = modules
-		.filter(m => m.id.startsWith(`${site.internal.baseFolder}/pages/${page}`))
+		.filter(m => m.id.includes(`${site.internal.baseFolder}/pages/${page}`))
 		.map(m => ({
 			id: m.id,
 			dependencies: m.dependencies
-				.filter(d => d.startsWith(site.internal.baseFolder))
-				.map(d => d.replace(site.internal.baseFolder, '')),
-		}));
+				.filter(d => d.startsWith(config.internal.rootFolder))
+				.map(d => d.replace(config.internal.rootFolder, '')),
+		}))?.[0]?.dependencies;
 
-	console.log(children);
-
-	const entries = Object.entries(manifest).filter(
-		([key]) =>
-			key.includes(`/pages/${page}.`) &&
-			/.(js|mjs|jsx|ts|tsx|md|mdx)$/.test(key),
-	);
-
-	if (!entries.length) return '';
-	if (entries.length !== 1) {
-		throw new Error(
-			'something went wrong while collecting assets for page ' + page,
-		);
-	}
-
-	return entries[0]
-		.map(v => {
-			if (!Array.isArray(v)) return '';
-
-			return v
-				.map((e: unknown) => {
-					if (typeof e !== 'string') return '';
-
-					if (e.endsWith('.js'))
-						return `<link rel="modulepreload" href="${e}"/>`;
-					if (e.endsWith('.css')) return `<link rel="stylesheet" href="${e}"/>`;
-
-					return '';
-				})
-				.join('');
+	const entries: string[] = Object.entries(manifest)
+		.filter(([key]) => {
+			const isPage =
+				key.includes(`/pages/${page}.`) &&
+				/.(js|mjs|jsx|ts|tsx|md|mdx)$/.test(key);
+			const isDep = children.some(c => key.includes(c));
+			return isPage || isDep;
 		})
-		.join('');
+		.map(x => x[1])
+		.flat();
+
+	const preload = [...new Set(entries)];
+
+	const html = preload
+		.map(v => {
+			if (v.endsWith('.js')) return `<link rel="modulepreload" href="${v}"/>`;
+			if (v.endsWith('.css')) return `<link rel="stylesheet" href="${v}"/>`;
+			return '';
+		})
+		.join('\n');
+
+	return html;
 };

--- a/packages/core/src/server/ssr.ts
+++ b/packages/core/src/server/ssr.ts
@@ -174,7 +174,7 @@ const collectPreload = async (
 
 	return entries[0]
 		.map(v => {
-			if (!Array.isArray(v) || v.length !== 2) return '';
+			if (!Array.isArray(v)) return '';
 
 			return v
 				.map((e: unknown) => {

--- a/packages/example/sites/default/components/lol.tsx
+++ b/packages/example/sites/default/components/lol.tsx
@@ -1,0 +1,1 @@
+import './lol.css';

--- a/packages/example/sites/default/pages/index.tsx
+++ b/packages/example/sites/default/pages/index.tsx
@@ -2,6 +2,8 @@ import { createSP, Head, Link } from '@snowstorm/core';
 import { useState } from 'react';
 import styles from './index.module.css';
 
+import './../components/lol';
+
 const { useSP: useStuff } = createSP('load-stuff', async () => ({ hi: 1 }), {
 	type: 'dynamic',
 	runOnClient: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,7 @@ importers:
 
   packages/core:
     specifiers:
+      '@rollup/pluginutils': ^4.1.1
       '@snowstorm/head': link:../head
       '@snowstorm/serverprops': link:../serverprops
       '@types/koa': ^2.13.4
@@ -87,6 +88,7 @@ importers:
       website-scraper: ^4.2.3
       wouter: ^2.7.5
     dependencies:
+      '@rollup/pluginutils': 4.1.1
       '@snowstorm/head': link:../head
       '@snowstorm/serverprops': link:../serverprops
       '@vitejs/plugin-react-refresh': 1.3.6


### PR DESCRIPTION
Signed-off-by: Henry <mail@henrygressmann.de>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.6.1--canary.22.d586580.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @snowstorm/cli@0.6.1--canary.22.d586580.0
  npm install @snowstorm/core@0.6.1--canary.22.d586580.0
  npm install @snowstorm/head@0.6.1--canary.22.d586580.0
  npm install @snowstorm/serverprops@0.6.1--canary.22.d586580.0
  # or 
  yarn add @snowstorm/cli@0.6.1--canary.22.d586580.0
  yarn add @snowstorm/core@0.6.1--canary.22.d586580.0
  yarn add @snowstorm/head@0.6.1--canary.22.d586580.0
  yarn add @snowstorm/serverprops@0.6.1--canary.22.d586580.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
