### PR TITLE
fix: fix plugin loading on multisite projects

### DIFF
--- a/packages/core/src/client/index.tsx
+++ b/packages/core/src/client/index.tsx
@@ -2,7 +2,7 @@ import { hydrateSPs } from '@snowstorm/serverprops/lib/internal';
 import React from 'react';
 
 import {} from 'react-dom/next';
-import { createRoot } from 'react-dom';
+import { createRoot, hydrateRoot } from 'react-dom';
 import { Router } from 'wouter';
 import {
 	basePath,
@@ -42,5 +42,5 @@ if (!loc.startsWith('/')) loc = '/' + loc;
 
 	const hydrate = Boolean(element?.childNodes.length);
 	if (hydrate) hydrateSPs();
-	if (element) createRoot(element, { hydrate }).render(page);
+	if (element) hydrateRoot(element, page);
 })();

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -9,7 +9,6 @@ import { startSite } from './site.js';
 import { isSnowstormProject } from './utils/is-snowstorm-project.js';
 
 import { createRequire } from 'module';
-import { rejects } from 'assert';
 import { createServer } from 'http';
 const require = createRequire(import.meta.url);
 

--- a/packages/core/src/server/site.ts
+++ b/packages/core/src/server/site.ts
@@ -125,14 +125,18 @@ const viteBaseConfig = (
 		},
 	};
 
+	const defaultPlugins =
+		(config.site.build?.vitePlugins as Array<PluginOption | PluginOption[]>) ||
+		[];
+
 	res?.plugins?.push(
 		// snowstorm's default plugins
 		...[
 			react({ jsxRuntime: 'classic' }),
 			snowstormCollectModules(site.internal.baseFolder),
 		],
-		// default site plugins
-		...(site.build.vitePlugins || []),
+		// default plugins
+		...defaultPlugins,
 	);
 
 	// site specific plugins
@@ -141,11 +145,7 @@ const viteBaseConfig = (
 		config.internal.sitesFolder &&
 		site.pagesFolder.startsWith(config.internal.sitesFolder)
 	) {
-		res?.plugins?.push(
-			...((config.site.build?.vitePlugins as Array<
-				PluginOption | PluginOption[]
-			>) || []),
-		);
+		res?.plugins?.push(...(site.build.vitePlugins || []));
 	}
 
 	return res;

--- a/packages/core/src/server/utils/import-file.ts
+++ b/packages/core/src/server/utils/import-file.ts
@@ -1,5 +1,5 @@
 import glob from 'fast-glob';
-import { readFile, unlink, writeFile } from 'fs/promises';
+import { unlink, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { compile } from './compile.js';
 


### PR DESCRIPTION
Signed-off-by: Henry Gressmann <mail@henrygressmann.de>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.7.3--canary.27.9e2f605.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @snowstorm/cli@0.7.3--canary.27.9e2f605.0
  npm install @snowstorm/core@0.7.3--canary.27.9e2f605.0
  npm install @snowstorm/head@0.7.3--canary.27.9e2f605.0
  npm install @snowstorm/serverprops@0.7.3--canary.27.9e2f605.0
  # or 
  yarn add @snowstorm/cli@0.7.3--canary.27.9e2f605.0
  yarn add @snowstorm/core@0.7.3--canary.27.9e2f605.0
  yarn add @snowstorm/head@0.7.3--canary.27.9e2f605.0
  yarn add @snowstorm/serverprops@0.7.3--canary.27.9e2f605.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
