### PR TITLE
fix: remove floc in dev mode, fix missing location global

### DIFF
--- a/packages/core/src/client/index.tsx
+++ b/packages/core/src/client/index.tsx
@@ -12,6 +12,9 @@ import {
 } from './router';
 import makeMatcher from '@snowstorm/router/lib/matcher';
 
+// prevent flash-of-unstyled-content in dev-mode
+document.querySelector('.__snowstorm-dev-floc')?.remove();
+
 const element = document.getElementById('app');
 
 let loc = document.location.pathname;

--- a/packages/core/src/server/ssr.ts
+++ b/packages/core/src/server/ssr.ts
@@ -9,10 +9,13 @@ import { fileIsPage } from './utils/is-page';
 import Youch from '@explodingcamera/youch';
 
 import ssrPrepass from 'react-ssr-prepass';
+import EventEmitter from 'events';
 
 const startDate = Date.now();
 const version = startDate.toString();
 const ABORT_DELAY = 2000;
+
+EventEmitter.defaultMaxListeners = 100;
 
 export const ssr =
 	({
@@ -93,8 +96,12 @@ export const ssr =
 			}
 
 			// const props: string = await serverprops.collectProps();
-			const head: string = getHead();
+			let head: string = getHead();
 			const basePath = site.basePath === '/' ? '' : site.basePath;
+
+			if (dev) {
+				head += `<style type="text/css" class="__snowstorm-dev-floc">* {display: none;}</style>`;
+			}
 
 			const doc = htmlFile
 				.replace(/\/_snowstorm\/index.js/g, `/_snowstorm/index.js?v=${version}`)

--- a/packages/router/src/use-location.ts
+++ b/packages/router/src/use-location.ts
@@ -23,7 +23,7 @@ export type HookNavigationOptions<H extends BaseLocationHook> =
 			: Record<string, unknown>
 		: Record<string, unknown>;
 
-const location = global.location || { pathname: '/' };
+const location = window?.location || global?.location || { pathname: '/' };
 
 /**
  * History API docs @see https://developer.mozilla.org/en-US/docs/Web/API/History


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.11.1--canary.31.6973fce.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @snowstorm/cli@0.11.1--canary.31.6973fce.0
  npm install @snowstorm/core@0.11.1--canary.31.6973fce.0
  npm install @snowstorm/head@0.11.1--canary.31.6973fce.0
  npm install @snowstorm/router@0.11.1--canary.31.6973fce.0
  npm install @snowstorm/serverprops@0.11.1--canary.31.6973fce.0
  # or 
  yarn add @snowstorm/cli@0.11.1--canary.31.6973fce.0
  yarn add @snowstorm/core@0.11.1--canary.31.6973fce.0
  yarn add @snowstorm/head@0.11.1--canary.31.6973fce.0
  yarn add @snowstorm/router@0.11.1--canary.31.6973fce.0
  yarn add @snowstorm/serverprops@0.11.1--canary.31.6973fce.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
